### PR TITLE
delete instruction banner

### DIFF
--- a/captchupFiles/captchup_db.js
+++ b/captchupFiles/captchup_db.js
@@ -10,11 +10,10 @@ var captchup = function() {
   $.get("https://captchup-api.herokuapp.com/db", function( data ) {
     var string;
     if ( data.gameType == 'imgAssoc') {
-      string = '<p><img src="http://i.imgur.com/WGLuxAA.png"width="450"></img></p>'+
-        '<img src="' +  data.mainString  + '" width="450"></img>'+
-        '<p><img onclick="selectImage(event)" src="' +  data.promptStrings[0]  + '" width="150">'+
-        '<img onclick="selectImage(event)" src="' +  data.promptStrings[1]  + '" width="150">'+
-        '<img onclick="selectImage(event)" src="' +  data.promptStrings[2]  + '" width="150"></p>';
+      string = '<img src="' +  data.mainString  + '" width="600"></img>'+
+        '<p><img onclick="selectImage(event)" src="' +  data.promptStrings[0]  + '" width="200">'+
+        '<img onclick="selectImage(event)" src="' +  data.promptStrings[1]  + '" width="200">'+
+        '<img onclick="selectImage(event)" src="' +  data.promptStrings[2]  + '" width="200"></p>';
     } else {
       string = '';
     }


### PR DESCRIPTION
Captcha instructions for games are now displayed on the 'main image'.
This PR deletes the banner with instructions.
This PR resizes the main images from 450px to 600px wide.
This PR resizes the decoy images from 150px to 200px wide.
